### PR TITLE
Add provision script used by vagrant of codeocean

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#### DOCKERCONTAINERPOOL INSTALL ####
+cd /home/vagrant/dockercontainerpool
+
+# use the same config files as in codeocean
+cp ../codeocean/config/database.yml config/database.yml
+cp ../codeocean/config/docker.yml.erb config/docker.yml.erb
+
+# use the example config file
+cp config/mnemosyne.yml.example config/mnemosyne.yml
+
+# install dependencies
+bundle install


### PR DESCRIPTION
This adds a provision script that will used by vagrant in the [codeocean project](https://github.com/openHPI/codeocean).