### PR TITLE
Enable support for runner management

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   scope 'docker_container_pool' do
-    get 'get_container/:execution_environment_id', to: 'container_pool#get_container'
-    get 'return_container/:container_id', to: 'container_pool#return_container'
-    get 'destroy_container/:container_id', to: 'container_pool#destroy_container'
+    post 'get_container/:execution_environment_id', to: 'container_pool#get_container'
+    put 'return_container/:container_id', to: 'container_pool#return_container'
+    delete 'destroy_container/:container_id', to: 'container_pool#destroy_container'
     get 'quantities', to: 'container_pool#quantities'
     get 'dump_info', to: 'container_pool#dump_info'
     get 'available_images', to: 'container_pool#available_images'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     post 'get_container/:execution_environment_id', to: 'container_pool#get_container'
     put 'return_container/:container_id', to: 'container_pool#return_container'
     delete 'destroy_container/:container_id', to: 'container_pool#destroy_container'
+    post 'reuse_container/:container_id', to: 'container_pool#reuse_container'
     get 'quantities', to: 'container_pool#quantities'
     get 'dump_info', to: 'container_pool#dump_info'
     get 'available_images', to: 'container_pool#available_images'

--- a/lib/container_pool.rb
+++ b/lib/container_pool.rb
@@ -85,7 +85,7 @@ class ContainerPool
     end
   end
 
-  def get_container(execution_environment)
+  def get_container(execution_environment, inactivity_timeout = nil)
     # if pooling is active, do pooling, otherwise just create an container and return it
     if config[:active]
       container = nil
@@ -118,7 +118,7 @@ class ContainerPool
       container&.status = :executing
     end
     # returning nil is no problem. then the pool is just depleted.
-    container.docker_client.kill_after_timeout(container) unless container.blank?
+    container.docker_client.kill_after_timeout(container, inactivity_timeout) unless container.blank?
     container
   end
 

--- a/lib/container_pool.rb
+++ b/lib/container_pool.rb
@@ -160,7 +160,7 @@ class ContainerPool
   end
 
   def refill_for_execution_environment(execution_environment)
-    refill_count = [execution_environment.pool_size - @all_containers[execution_environment.id].length, config[:refill][:batch_size]].min
+    refill_count = [execution_environment.pool_size - @containers[execution_environment.id].length, config[:refill][:batch_size]].min
     if refill_count > 0
       Rails.logger.info('Adding ' + refill_count.to_s + ' containers for execution_environment ' + execution_environment.name)
       multiple_containers = refill_count.times.map { create_container(execution_environment) }

--- a/lib/docker_client.rb
+++ b/lib/docker_client.rb
@@ -11,6 +11,7 @@ class DockerClient
   LOCAL_WORKSPACE_ROOT = File.expand_path(self.config[:workspace_root])
   RECYCLE_CONTAINERS = true
   RETRY_COUNT = 2
+  LIMIT_CONTAINER_LIFETIME = false
   MINIMUM_CONTAINER_LIFETIME = 10.minutes
   MAXIMUM_CONTAINER_LIFETIME = 20.minutes
   SELF_DESTROY_GRACE_PERIOD = 2.minutes
@@ -78,27 +79,29 @@ class DockerClient
     container.re_use = true
     container.docker_client = new(execution_environment: execution_environment)
 
-    Thread.new do
-      timeout = Random.rand(MINIMUM_CONTAINER_LIFETIME..MAXIMUM_CONTAINER_LIFETIME) # seconds
-      sleep(timeout)
-      container.re_use = false
-      if container.status != :executing
-        container.docker_client.kill_container(container, false)
-        Rails.logger.info('Killing container in status ' + container.status.to_s + ' after ' + (Time.now - container.start_time).to_s + ' seconds.')
-      else
-        Thread.new do
-          timeout = SELF_DESTROY_GRACE_PERIOD.to_i
-          sleep(timeout)
+    if LIMIT_CONTAINER_LIFETIME
+      Thread.new do
+        timeout = Random.rand(MINIMUM_CONTAINER_LIFETIME..MAXIMUM_CONTAINER_LIFETIME) # seconds
+        sleep(timeout)
+        container.re_use = false
+        if container.status != :executing
           container.docker_client.kill_container(container, false)
-          Rails.logger.info('Force killing container in status ' + container.status.to_s + ' after ' + (Time.now - container.start_time).to_s + ' seconds.')
-        ensure
-          # guarantee that the thread is releasing the DB connection after it is done
-          ActiveRecord::Base.connection_pool.release_connection
+          Rails.logger.info('Killing container in status ' + container.status.to_s + ' after ' + (Time.now - container.start_time).to_s + ' seconds.')
+        else
+          Thread.new do
+            timeout = SELF_DESTROY_GRACE_PERIOD.to_i
+            sleep(timeout)
+            container.docker_client.kill_container(container, false)
+            Rails.logger.info('Force killing container in status ' + container.status.to_s + ' after ' + (Time.now - container.start_time).to_s + ' seconds.')
+          ensure
+            # guarantee that the thread is releasing the DB connection after it is done
+            ActiveRecord::Base.connection_pool.release_connection
+          end
         end
+      ensure
+        # guarantee that the thread is releasing the DB connection after it is done
+        ActiveRecord::Base.connection_pool.release_connection
       end
-    ensure
-      # guarantee that the thread is releasing the DB connection after it is done
-      ActiveRecord::Base.connection_pool.release_connection
     end
 
     container

--- a/lib/docker_client.rb
+++ b/lib/docker_client.rb
@@ -242,7 +242,7 @@ class DockerClient
   end
 
   def self.mapped_ports(execution_environment)
-    (execution_environment.exposed_ports || '').gsub(/\s/, '').split(',').map do |port|
+    execution_environment.exposed_ports.map do |port|
       ["#{port}/tcp", [{'HostPort' => PortPool.available_port.to_s}]]
     end.to_h
   end


### PR DESCRIPTION
This MR:

- uses a database array for `exposed_ports` (breaking change)
- changes the HTTP verbs (breaking change)
- adds support for a dedicated `inactivityTimeout`
- prevents containers from self-destroying if not used
- adds a route to query available Docker images