### PR TITLE
Adapt Quantities to Differ Between Used and Idle Runners

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -16,7 +16,7 @@ class PingController < ApplicationController
 
   def docker_connected!
     # any unhandled exception leads to a HTTP 500 response.
-    raise ContainerPool::EmptyError unless ContainerPool.instance.quantities.values.sum.positive?
+    raise ContainerPool::EmptyError unless ContainerPool.instance.quantities.values.pluck(:idleRunners).sum.positive?
   end
 
   def postgres_connected!

--- a/lib/container_pool.rb
+++ b/lib/container_pool.rb
@@ -137,7 +137,16 @@ class ContainerPool
   end
 
   def quantities
-    @containers.transform_values { |value| value.length }
+    @all_containers.map do |execution_environment_id, _|
+      {
+        execution_environment_id => {
+          id: execution_environment_id,
+          prewarmingPoolSize: ExecutionEnvironment.find(execution_environment_id).pool_size,
+          idleRunners: @containers[execution_environment_id].length,
+          usedRunners: @all_containers[execution_environment_id].length - @containers[execution_environment_id].length
+        }
+      }
+    end.inject(:merge)
   end
 
   def dump_info

--- a/spec/lib/container_pool_spec.rb
+++ b/spec/lib/container_pool_spec.rb
@@ -90,7 +90,14 @@ describe ContainerPool do
   describe '.quantities' do
     it 'maps execution environments to quantities of available containers' do
       expect(described_class.quantities.keys).to eq(ExecutionEnvironment.all.map(&:id))
-      expect(described_class.quantities.values.uniq).to eq([0])
+      expected = {
+        id: @execution_environment.id,
+        prewarmingPoolSize: @execution_environment.pool_size,
+        idleRunners: 0,
+        usedRunners: 0
+      }
+      expect(described_class.quantities[@execution_environment.id]).to eq(expected)
+      expect(described_class.quantities.length).to eq(1)
     end
   end
 


### PR DESCRIPTION
This PR changes the response format of the `/docker_container_pool/quantities` route to work with [codeocean#1105](https://github.com/openHPI/codeocean/pull/1105)